### PR TITLE
Add method to move some schedules all at once like inserting/removing new column in Excel

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -28,9 +28,10 @@ jQuery(document).ready(function(){
         timeLineY:60,       // height(px)
         verticalScrollbar:20,   // scrollbar (px)
         timeLineBorder:2,   // border(top and bottom)
+        bundleMoveWidth:6,  // width to move all schedules to the right of the clicked time line cell
         debug:"#debug",     // debug string output elements
         rows : {
-            '1' : {
+            '0' : {
                 title : 'Title Area',
                 schedule:[
                     {
@@ -49,7 +50,7 @@ jQuery(document).ready(function(){
                     }
                 ]
             },
-            '2' : {
+            '1' : {
                 title : 'Title Area',
                 schedule:[
                     {
@@ -178,6 +179,11 @@ jQuery(document).ready(function(){
                 <td colspan="2">timeLineBorder</td>
                 <td>Integer</td>
                 <td>border(top and bottom)</td>
+            </tr><tr>
+                <td colspan="2">bundleMoveWidth</td>
+                <td>Integer</td>
+                <td>width to move all schedules to the right of the clicked time line cell.
+                </td>
             </tr>
             <tr>
                 <td colspan="2">debug</td>

--- a/js/jq.schedule.js
+++ b/js/jq.schedule.js
@@ -288,14 +288,14 @@
             // クリックイベント
             // left click
             $timeline.find(".tl").click(function(){
-                element.moveAllRightCells(jQuery(this).data("timeline"), jQuery(this), setting.bundleMoveWidth);
+                element.moveSchedules(jQuery(this).data("timeline"), jQuery(this), setting.bundleMoveWidth);
                 if(setting.time_click){
                     setting.time_click(this,jQuery(this).data("time"),jQuery(this).data("timeline"),timelineData[jQuery(this).data("timeline")]);
                 }
             });
             // right click
             $timeline.find(".tl").on("contextmenu", function(e){
-                element.moveAllRightCells(jQuery(this).data("timeline"), jQuery(this), -1 * setting.bundleMoveWidth);
+                element.moveSchedules(jQuery(this).data("timeline"), jQuery(this), -1 * setting.bundleMoveWidth);
                 if(setting.time_click){
                     setting.time_click(this,jQuery(this).data("time"),jQuery(this).data("timeline"),timelineData[jQuery(this).data("timeline")]);
                 }
@@ -467,7 +467,7 @@
 
         };
         // move all cells of the right of the specified time line cell
-        this.moveAllRightCells = function(timeline, baseTimeLineCell, moveWidth){
+        this.moveSchedules = function(timeline, baseTimeLineCell, moveWidth){
             var $bar_list = $element.find('.sc_main .timeline').eq(timeline).find(".sc_Bar");
             for(var i=0;i<$bar_list.length;i++){
                 var $bar = jQuery($bar_list[i]);


### PR DESCRIPTION
This pull request is to add a new method.

When you want to shift some schedules all at once, in the current version, all target schedules must be moved by drag & drop one by one.

So,  I added the following method like inserting/removing new column in Excel. 
1. left(right) click time line cell.
2. move all schedules to the right of the clicked timeline cell to the right (left).

Please consider the merge.


これは機能追加を行うためのプルリクエストです．

スケジュールの時間を一斉にずらしたいというとき，
現状だと対象となる全てのスケジュールを逐一ドラック&ドロップで移動しなければなりません．

そこで，エクセルにおける列の挿入・削除のような，次の機能を追加しました．
1. タイムラインセルを左(右)クリックする．
2. クリックされたタイムラインセルより右にあるスケジュールを全て右(左)に動かす．

マージの検討をお願いします．