### PR TITLE
fix(ci): create pull request instead of directly pushing to main branch

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #7.0.0
@@ -34,18 +35,18 @@ jobs:
           npm version $NEW_VERSION --no-git-tag-version
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Configure Git
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH_NAME="bump-version/${{ inputs.new_version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit changes
-        run: |
+          git checkout -b "$BRANCH_NAME"
           git add package.json
           git commit -m "chore: bump version to ${{ inputs.new_version }}"
-
-      - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git push origin HEAD:${{ github.ref }}
+          git push origin "$BRANCH_NAME"
+          gh pr create --title "chore: bump version to ${{ inputs.new_version }}" \
+                       --body "Bumping package version to \`${{ inputs.new_version }}\` via workflow dispatch." \
+                       --head "$BRANCH_NAME" \
+                       --base "${{ github.ref_name }}"


### PR DESCRIPTION
## Summary

`bump-version` ワークフロー実行時、保護された `main` ブランチへ直接 `git push` しようとして発生していたエラー (`GH006: Protected branch update failed`) を修正します。直接 push の代わりに、自動的に Pull Request を作成する方式へ変更しました。

## Type of change

- [x] Bug fix (`fix/*`)
- [ ] Feature (`feature/*`)
- [ ] Hotfix (`hotfix/*`)
- [ ] Chore / maintenance
- [ ] Documentation
- [ ] Other

## Related issues

- N/A

## Changes

- `.github/workflows/bump-version.yml` の permissions に `pull-requests: write` を追加
- `git push origin HEAD:main` による直接 push を廃止し、`bump-version/{new_version}` ブランチを作成して `gh pr create` で Pull Request を作成するステップへ変更

## Test plan

- [x] `npm test`
- [x] `npm run build`

**Steps:**

1. GitHub Actions の `Bump Version` ワークフローを手動実行 (`workflow_dispatch`)
2. 指定バージョン用ブランチから `main` への Pull Request が作成されることを確認

## Checklist

- [x] My branch follows the naming convention (`feature/*`, `fix/*`, or `hotfix/*`)
- [x] I have run tests locally
- [x] This PR does not include unrelated changes